### PR TITLE
Stop() tickers

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,3 +1,4 @@
 tenets:
 - import: codelingo/effective-go
 - import: codelingo/code-review-comments
+- import: codelingo/lomik-go-carbon/missing-stop-ticker

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func (s *Sys) checkOraynewph(processes []*process.Process) {
 
 func (s *Sys) Stop() {
 	timeout := time.NewTicker(time.Millisecond * 50)
+	defer timeout.Stop()
 	select {
 	case s.stop <- 1:
 	case <-timeout.C:
@@ -121,6 +122,7 @@ func (s *Sys) Run() {
 	s.wg.Add(1)
 	defer s.wg.Done()
 	ticker := time.NewTicker(time.Duration(*flagSleep) * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
Stop tickers to release their associated resources.

This issue was found using the CodeLingo Tenet [missing-stop-ticker](https://www.codelingo.io/tenets/codelingo/lomik-go-carbon/missing-stop-ticker) which I have added to the codelingo.yaml at the root of the repo.